### PR TITLE
Updates for finishing classification tasks without getting stuck in SGD

### DIFF
--- a/atm/constants.py
+++ b/atm/constants.py
@@ -14,7 +14,7 @@ METRICS = ['f1', 'roc_auc', 'accuracy', 'mu_sigma']
 SCORE_TARGETS = ['cv', 'test']
 BUDGET_TYPES = ['none', 'classifier', 'walltime']
 METHODS = ['logreg', 'svm', 'sgd', 'dt', 'et', 'rf', 'gnb', 'mnb', 'bnb',
-              'gp', 'pa', 'knn', 'dbn', 'mlp']
+              'gp', 'pa', 'knn', 'dbn', 'mlp', 'ada']
 TUNERS = ['uniform', 'gp', 'gp_ei', 'gp_eivel']
 SELECTORS = ['uniform', 'ucb1', 'bestk', 'bestkvel', 'purebestkvel', 'recentk',
              'recentkvel', 'hieralg']
@@ -59,6 +59,7 @@ METHODS_MAP = {
     'knn': 'k_nearest_neighbors.json',
     'dbn': 'deep_belief_network.json',
     'mlp': 'multi_layer_perceptron.json',
+    'ada': 'adaboost.json'
 }
 
 class ClassifierStatus:

--- a/methods/adaboost.json
+++ b/methods/adaboost.json
@@ -1,0 +1,16 @@
+{   
+    "name": "ada",
+    "class": "sklearn.ensemble.AdaBoostClassifier",
+    "parameters": {
+        "n_estimators": {
+           "type": "int",
+           "range": [25,500]
+        },
+        "learning_rate": {
+           "type": "float",
+           "range": [0.5,10]
+        }
+    },
+    "root_parameters": ["n_estimators", "learning_rate"],
+    "conditions": {}
+}

--- a/methods/gaussian_process.json
+++ b/methods/gaussian_process.json
@@ -21,6 +21,10 @@
         "periodicity": {
            "type": "int_cat",
            "range": [0, 1]
+        },
+        "max_iter_predict": {
+           "type": "int",
+           "range": [5000]
         }
     },
     "root_parameters": ["kernel"],

--- a/methods/multi_layer_perceptron.json
+++ b/methods/multi_layer_perceptron.json
@@ -53,6 +53,10 @@
         "_scale": {
            "type": "string",
            "range": [true]
+        },
+        "max_iter": {
+           "type": "int",
+           "range": [50000]
         }
     },
     "root_parameters": ["batch_size", "solver", "alpha", "activation", "num_hidden_layers", "_scale"],

--- a/methods/support_vector_machine.json
+++ b/methods/support_vector_machine.json
@@ -41,6 +41,10 @@
         "_scale": {
            "type": "bool",
            "range": [true]
+        },
+        "max_iter": {
+           "type": "int",
+           "range": [50000]
         }
     },
     "root_parameters": ["C", "kernel", "probability", "shrinking", "cache_size", "class_weight", "_scale"],


### PR DESCRIPTION
updates to get SVC, MLP, and GP to not get stuck w/ skewed data by limiting total number of allowed iterations before solver terminates.

Added adaboost configuration json file.