### PR TITLE
adding mcc as another metric

### DIFF
--- a/atm/constants.py
+++ b/atm/constants.py
@@ -10,7 +10,7 @@ from btb.selection import Uniform as UniformSelector, UCB1,\
 # TODO: convert these lists and classes to something more elegant, like enums
 # perhaps?
 SQL_DIALECTS = ['sqlite', 'mysql']
-METRICS = ['f1', 'roc_auc', 'accuracy', 'mu_sigma']
+METRICS = ['f1', 'roc_auc', 'accuracy', 'mu_sigma', 'mcc']
 SCORE_TARGETS = ['cv', 'test']
 BUDGET_TYPES = ['none', 'classifier', 'walltime']
 METHODS = ['logreg', 'svm', 'sgd', 'dt', 'et', 'rf', 'gnb', 'mnb', 'bnb',
@@ -98,6 +98,7 @@ class Metrics:
     AP = 'ap'               # average precision
     PR_CURVE = 'pr_curve'
     ROC_CURVE = 'roc_curve'
+    MCC = 'mcc'
 
 METRICS_BINARY = [
     Metrics.ACCURACY,
@@ -105,6 +106,7 @@ METRICS_BINARY = [
     Metrics.F1,
     Metrics.ROC_AUC,
     Metrics.AP,
+    Metrics.MCC,
 ]
 
 METRICS_MULTICLASS = [

--- a/atm/metrics.py
+++ b/atm/metrics.py
@@ -2,7 +2,7 @@ from sklearn.model_selection import StratifiedKFold
 from sklearn.preprocessing import LabelEncoder, OneHotEncoder
 from sklearn.metrics import f1_score, precision_recall_curve, auc, roc_curve,\
                             accuracy_score, cohen_kappa_score, roc_auc_score,\
-                            average_precision_score
+                            average_precision_score, matthews_corrcoef
 
 import numpy as np
 import pandas as pd
@@ -69,6 +69,7 @@ def get_metrics_binary(y_true, y_pred, y_pred_probs, include_curves=False):
         Metrics.ACCURACY: accuracy_score(y_true, y_pred),
         Metrics.COHEN_KAPPA: cohen_kappa_score(y_true, y_pred),
         Metrics.F1: f1_score(y_true, y_pred),
+        Metrics.MCC: matthews_corrcoef(y_true, y_pred),
         Metrics.ROC_AUC: np.nan,
         Metrics.AP: np.nan,
     }


### PR DESCRIPTION
Adding the Matthews Correlation Coefficient as another metric that can be chosen by the user of the ATM tool, which is a good measure of the performance of the classifier when your class distribution is skewed.

See: http://scikit-learn.org/stable/modules/generated/sklearn.metrics.matthews_corrcoef.html