### PR TITLE
Rework judgment metrics

### DIFF
--- a/atm/config.py
+++ b/atm/config.py
@@ -330,9 +330,10 @@ def add_arguments_datarun(parser):
     # Which data to use for computing judgment score
     #   cv   - cross-validated performance on training data
     #   test - performance on test data
+    #   mu_sigma - lower confidence bound on cv score
     parser.add_argument('--score-target', choices=SCORE_TARGETS,
                         help='whether to compute metrics by cross-validation or on '
-                        'test data (if available)')
+                        'test data')
 
     return parser
 

--- a/atm/constants.py
+++ b/atm/constants.py
@@ -10,11 +10,10 @@ from btb.selection import Uniform as UniformSelector, UCB1,\
 # TODO: convert these lists and classes to something more elegant, like enums
 # perhaps?
 SQL_DIALECTS = ['sqlite', 'mysql']
-METRICS = ['f1', 'roc_auc', 'accuracy', 'mu_sigma', 'mcc']
-SCORE_TARGETS = ['cv', 'test']
+SCORE_TARGETS = ['cv', 'test', 'mu_sigma']
 BUDGET_TYPES = ['none', 'classifier', 'walltime']
 METHODS = ['logreg', 'svm', 'sgd', 'dt', 'et', 'rf', 'gnb', 'mnb', 'bnb',
-              'gp', 'pa', 'knn', 'dbn', 'mlp', 'ada']
+           'gp', 'pa', 'knn', 'dbn', 'mlp', 'ada']
 TUNERS = ['uniform', 'gp', 'gp_ei', 'gp_eivel']
 SELECTORS = ['uniform', 'ucb1', 'bestk', 'bestkvel', 'purebestkvel', 'recentk',
              'recentkvel', 'hieralg']
@@ -97,9 +96,22 @@ class Metrics:
     ROC_AUC_MICRO = 'roc_auc_micro'
     ROC_AUC_MACRO = 'roc_auc_macro'
     AP = 'ap'               # average precision
+    MCC = 'mcc'             # matthews correlation coefficient
     PR_CURVE = 'pr_curve'
     ROC_CURVE = 'roc_curve'
-    MCC = 'mcc'
+
+METRIC_DEFAULT_SCORES = {
+    Metrics.ACCURACY: 0.0,
+    Metrics.RANK_ACCURACY: 0.0,
+    Metrics.COHEN_KAPPA: 0.0,
+    Metrics.F1: 0.0,
+    Metrics.F1_MICRO: 0.0,
+    Metrics.F1_MACRO: 0.0,
+    Metrics.ROC_AUC: 0.5,
+    Metrics.ROC_AUC_MICRO: 0.5,
+    Metrics.ROC_AUC_MACRO: 0.5,
+    Metrics.AP: 0.0,
+}
 
 METRICS_BINARY = [
     Metrics.ACCURACY,
@@ -120,17 +132,6 @@ METRICS_MULTICLASS = [
     Metrics.ROC_AUC_MACRO,
 ]
 
-METRIC_DEFAULT_SCORES = {
-    Metrics.ACCURACY: 0.0,
-    Metrics.RANK_ACCURACY: 0.0,
-    Metrics.COHEN_KAPPA: 0.0,
-    Metrics.F1: 0.0,
-    Metrics.F1_MICRO: 0.0,
-    Metrics.F1_MACRO: 0.0,
-    Metrics.ROC_AUC: 0.5,
-    Metrics.ROC_AUC_MICRO: 0.5,
-    Metrics.ROC_AUC_MACRO: 0.5,
-    Metrics.AP: 0.0,
-}
+METRICS = list(set(METRICS_BINARY + METRICS_MULTICLASS))
 
 N_FOLDS_DEFAULT = 10

--- a/atm/database.py
+++ b/atm/database.py
@@ -275,6 +275,8 @@ class Database(object):
             def mu_sigma_judgment_metric(self):
                 # compute the lower confidence bound on the cross-validated
                 # judgment metric
+                if self.cv_judgment_metric is None:
+                    return None
                 return (self.cv_judgment_metric - 2 *
                         self.cv_judgment_metric_stdev)
 

--- a/atm/database.py
+++ b/atm/database.py
@@ -271,6 +271,13 @@ class Database(object):
             def trainable_params(self, value):
                 self.trainable_params64 = object_to_base_64(value)
 
+            @property
+            def mu_sigma_judgment_metric(self):
+                # compute the lower confidence bound on the cross-validated
+                # judgment metric
+                return (self.cv_judgment_metric - 2 *
+                        self.cv_judgment_metric_stdev)
+
             def __repr__(self):
                 params = ', '.join(['%s: %s' % i for i in self.params.items()])
                 return "<id=%d, params=(%s)>" % (self.id, params)
@@ -454,7 +461,7 @@ class Database(object):
         return None
 
     @try_with_session()
-    def get_best_classifier(self, session, score_target='mu_sigma',
+    def get_best_classifier(self, session, score_target,
                             dataset_id=None, datarun_id=None,
                             method=None, hyperpartition_id=None):
         """
@@ -462,13 +469,7 @@ class Database(object):
         classifier has the highest value of (score.mean - 2 * score.std)?
 
         score_target: indicates the metric by which to judge the best classifier.
-            One of ['mu_sigma', 'cv_judgment_metric', 'test_judgment_metric'].
         """
-        if score_target == 'mu_sigma':
-            func = lambda c: c.cv_judgment_metric - 2 * c.cv_judgment_metric_stdev
-        else:
-            func = attrgetter(score_target)
-
         classifiers = self.get_classifiers(dataset_id=dataset_id,
                                            datarun_id=datarun_id,
                                            method=method,
@@ -478,7 +479,7 @@ class Database(object):
         if not classifiers:
             return None
 
-        best = max(classifiers, key=func)
+        best = max(classifiers, key=attrgetter(score_target))
         return best
 
     ###########################################################################

--- a/atm/model.py
+++ b/atm/model.py
@@ -132,6 +132,8 @@ class Model(object):
                                                 n_folds=self.N_FOLDS)
         self.cv_judgment_metric = np.mean(df[self.judgment_metric])
         self.cv_judgment_metric_stdev = np.std(df[self.judgment_metric])
+        self.mu_sigma_judgment_metric = (self.cv_judgment_metric -
+                                         2 * self.cv_judgment_metric_stdev)
         return cv_scores
 
     def test_final_model(self, X, y):

--- a/atm/worker.py
+++ b/atm/worker.py
@@ -342,12 +342,13 @@ class Worker(object):
         def metric_string(model):
             if 'cv' in target or 'mu_sigma' in target:
                 return '%.3f +- %.3f' % (model.cv_judgment_metric,
-                                           2 * model.cv_judgment_metric_stdev)
+                                         2 * model.cv_judgment_metric_stdev)
             else:
                 return '%.3f' % model.test_judgment_metric
 
-        _log('Judgment metric (%s): %s' % (self.datarun.metric,
-                                           metric_string(model)))
+        _log('Judgment metric (%s, %s): %s' % (self.datarun.metric,
+                                               target[:-len('_judgment_metric')],
+                                               metric_string(model)))
 
         old_best = self.db.get_best_classifier(datarun_id=self.datarun.id,
                                                score_target=target)
@@ -356,8 +357,8 @@ class Worker(object):
                 _log('New best score! Previous best (classifier %s): %s' %
                      (old_best.id, metric_string(old_best)))
             else:
-                _log('Best so far (classifier %s): %.3f +- %.3f' %
-                     (old_best.id, metric_string(old_best)))
+                _log('Best so far (classifier %s): %s' % (old_best.id,
+                                                          metric_string(old_best)))
 
         return model, performance
 

--- a/atm/worker.py
+++ b/atm/worker.py
@@ -337,25 +337,27 @@ class Worker(object):
                                               self.aws_config)
         performance = model.train_test(train_path=train_path,
                                        test_path=test_path)
+        target = self.datarun.score_target
 
-        old_best = self.db.get_best_classifier(datarun_id=self.datarun.id)
+        def metric_string(model):
+            if 'cv' in target or 'mu_sigma' in target:
+                return '%.3f +- %.3f' % (model.cv_judgment_metric,
+                                           2 * model.cv_judgment_metric_stdev)
+            else:
+                return '%.3f' % model.test_judgment_metric
+
+        _log('Judgment metric (%s): %s' % (self.datarun.metric,
+                                           metric_string(model)))
+
+        old_best = self.db.get_best_classifier(datarun_id=self.datarun.id,
+                                               score_target=target)
         if old_best is not None:
-            old_val = old_best.cv_judgment_metric
-            old_err = 2 * old_best.cv_judgment_metric_stdev
-
-        new_val = model.cv_judgment_metric
-        new_err = 2 * model.cv_judgment_metric_stdev
-
-        _log('Judgment metric (%s): %.3f +- %.3f' %
-             (self.datarun.metric, new_val, new_err))
-
-        if old_best is not None:
-            if (new_val - new_err) > ():
-                _log('New best score! Previous best (classifier %s): %.3f +- %.3f' %
-                     (old_best.id, old_val, old_err))
+            if getattr(model, target) > getattr(old_best, target):
+                _log('New best score! Previous best (classifier %s): %s' %
+                     (old_best.id, metric_string(old_best)))
             else:
                 _log('Best so far (classifier %s): %.3f +- %.3f' %
-                     (old_best.id, old_val, old_err))
+                     (old_best.id, metric_string(old_best)))
 
         return model, performance
 

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -64,7 +64,8 @@ def print_summary(db, rid):
     classifiers = db.get_classifiers(datarun_id=rid)
     print 'Classifiers: %d total' % len(classifiers)
 
-    best = db.get_best_classifier(datarun_id=run.id)
+    best = db.get_best_classifier(score_target=run.score_target,
+                                  datarun_id=run.id)
     if best is not None:
         score = best.cv_judgment_metric
         err = 2 * best.cv_judgment_metric_stdev
@@ -94,7 +95,8 @@ def print_method_summary(db, rid):
                         ClassifierStatus.COMPLETE])
         print '\t%d errored, %d complete' % (errored, complete)
 
-        best = db.get_best_classifier(datarun_id=rid, method=alg)
+        best = db.get_best_classifier(score_target=run.score_target,
+                                      datarun_id=rid, method=alg)
         if best is not None:
             score = best.cv_judgment_metric
             err = 2 * best.cv_judgment_metric_stdev
@@ -121,7 +123,8 @@ def print_hp_summary(db, rid):
                         ClassifierStatus.COMPLETE])
         print '\t%d errored, %d complete' % (errored, complete)
 
-        best = db.get_best_classifier(datarun_id=rid, hyperpartition_id=hp)
+        best = db.get_best_classifier(score_target=run.score_target,
+                                      datarun_id=rid, hyperpartition_id=hp)
         if best is not None:
             score = best.cv_judgment_metric
             err = 2 * best.cv_judgment_metric_stdev


### PR DESCRIPTION
This branch makes `mu_sigma` a `score_target` rather than a `metric`. It is equal to two standard deviations below the mean of the cross-validated judgment metric, and represents a lower confidence bound on the performance of a classifier. 

In addition, `METRICS` has been updated to be the union of `METRICS_BINARY` and `METRICS_MULTICLASS` in  `constants.py`, and the code that prints the best-so-far classifier in `worker.py` now uses whatever score target is configured for the datarun (rather than always using `mu_sigma`).

Addresses #31 