### PR TITLE
updated class_weight attribute for SVC and LR from auto to balanced

### DIFF
--- a/methods/logistic_regression.json
+++ b/methods/logistic_regression.json
@@ -24,7 +24,7 @@
         },
         "class_weight": {
            "type": "string",
-           "range": ["auto"]
+           "range": ["balanced"]
         },
         "_scale": {
            "type": "bool",

--- a/methods/support_vector_machine.json
+++ b/methods/support_vector_machine.json
@@ -36,7 +36,7 @@
         },
         "class_weight": {
            "type": "string",
-           "range": ["auto"]
+           "range": ["balanced"]
         },
         "_scale": {
            "type": "bool",


### PR DESCRIPTION
auto and balanced do the same thing functionally, but the keyword auto will be deprecated starting with sklearn version 0.19, and balanced is now the preferred keyword to use.  balanced is supported starting with sklearn version 0.17

See: 
http://scikit-learn.org/0.16/modules/generated/sklearn.svm.SVC.html#sklearn.svm.SVC  [old]
http://scikit-learn.org/0.18/modules/generated/sklearn.svm.SVC.html#sklearn.svm.SVC [current]

http://scikit-learn.org/0.16/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn.linear_model.LogisticRegression [old]
http://scikit-learn.org/0.18/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn.linear_model.LogisticRegression [current]