### PR TITLE
Fix hyperparameter scientific notation

### DIFF
--- a/methods/gaussian_process.json
+++ b/methods/gaussian_process.json
@@ -12,7 +12,7 @@
         },
         "length_scale": {
            "type": "float_exp",
-           "range": [10e-5, 10e5]
+           "range": [1e-5, 1e5]
         },
         "alpha": {
            "type": "float",

--- a/methods/gaussian_process.json
+++ b/methods/gaussian_process.json
@@ -12,7 +12,7 @@
         },
         "length_scale": {
            "type": "float_exp",
-           "range": [1e-5, 1e5]
+           "range": [0.01, 100]
         },
         "alpha": {
            "type": "float",

--- a/methods/logistic_regression.json
+++ b/methods/logistic_regression.json
@@ -4,11 +4,11 @@
     "parameters": {
         "C": {
            "type": "float_exp",
-           "range": [10e-5, 10e5]
+           "range": [1e-5, 1e5]
         },
         "tol": {
            "type": "float_exp",
-           "range": [10e-5, 10e5]
+           "range": [1e-5, 1e5]
         },
         "penalty": {
            "type": "string",

--- a/methods/passive_aggressive.json
+++ b/methods/passive_aggressive.json
@@ -4,7 +4,7 @@
     "parameters": {
         "C": {
            "type": "float_exp",
-           "range": [10e-5, 10e5]
+           "range": [1e-5, 1e5]
         },
         "fit_intercept": {
            "type": "int_cat",

--- a/methods/stochastic_gradient_descent.json
+++ b/methods/stochastic_gradient_descent.json
@@ -12,7 +12,7 @@
         },
         "alpha": {
            "type": "float_exp",
-           "range": [10e-5, 10e5]
+           "range": [1e-5, 1e5]
         },
         "l1_ratio": {
            "type": "float",
@@ -32,7 +32,7 @@
         },
         "epsilon": {
            "type": "float_exp",
-           "range": [10e-5, 10e5]
+           "range": [1e-5, 1e5]
         },
         "learning_rate": {
            "type": "string",
@@ -40,7 +40,7 @@
         },
         "eta0": {
            "type": "float_exp",
-           "range": [10e-5, 10e5]
+           "range": [1e-5, 1e5]
         },
         "class_weight": {
            "type": "string",

--- a/methods/support_vector_machine.json
+++ b/methods/support_vector_machine.json
@@ -4,11 +4,11 @@
     "parameters": {
         "C": {
            "type": "float_exp",
-           "range": [10e-5, 10e5]
+           "range": [1e-5, 1e5]
         },
         "gamma": {
            "type": "float_exp",
-           "range": [10e-5, 10e5]
+           "range": [1e-5, 1e5]
         },
         "kernel": {
            "type": "string",
@@ -20,7 +20,7 @@
         },
         "coef0": {
             "type": "int",
-            "range": [-10e3, 10e3]
+            "range": [-1e3, 1e3]
         },
         "probability": {
             "type": "bool",


### PR DESCRIPTION
Fixes #53, and restores one gaussian process parameter to its original range (see https://github.com/HDI-Project/ATM/blob/50b592dd6a151a75470fb4120c1781ca7249d43f/atm/enumeration/classification/gp.py).