### PR TITLE
Add command line options to worker.py to allow verbose metrics reporting

### DIFF
--- a/atm/database.py
+++ b/atm/database.py
@@ -101,10 +101,10 @@ class Database(object):
             name = Column(String(100), nullable=False)
 
             # columns necessary for loading/processing data
-            description = Column(String(1000))
+            label_column = Column(String(100), nullable=False)
             train_path = Column(String(200), nullable=False)
             test_path = Column(String(200))
-            label_column = Column(String(100), nullable=False)
+            description = Column(String(1000))
 
             # metadata columns, for convenience
             n_examples = Column(Integer, nullable=False)

--- a/atm/model.py
+++ b/atm/model.py
@@ -45,7 +45,7 @@ class Model(object):
     N_FOLDS = 5
 
     def __init__(self, code, params, judgment_metric, label_column,
-                 testing_ratio=0.3):
+                 testing_ratio=0.3, verbose_metrics=False):
         """
         Parameters:
             code: the short method code (as defined in constants.py)
@@ -60,6 +60,7 @@ class Model(object):
         self.judgment_metric = judgment_metric
         self.label_column = label_column
         self.testing_ratio = testing_ratio
+        self.verbose_metrics = verbose_metrics
 
         # load the classifier method's class
         path = Method(METHODS_MAP[code]).class_path.split('.')
@@ -126,10 +127,18 @@ class Model(object):
         self.pipeline = Pipeline(steps)
 
     def cross_validate(self, X, y):
+        # TODO: this is hacky. See https://github.com/HDI-Project/ATM/issues/48
         binary = self.num_classes == 2
+        kwargs = {}
+        if self.verbose_metrics:
+            kwargs['include_curves'] = True
+            if not binary:
+                kwargs['include_per_class'] = True
+
         df, cv_scores = cross_validate_pipeline(pipeline=self.pipeline,
                                                 X=X, y=y, binary=binary,
-                                                n_folds=self.N_FOLDS)
+                                                n_folds=self.N_FOLDS, **kwargs)
+
         self.cv_judgment_metric = np.mean(df[self.judgment_metric])
         self.cv_judgment_metric_stdev = np.std(df[self.judgment_metric])
         self.mu_sigma_judgment_metric = (self.cv_judgment_metric -
@@ -143,14 +152,23 @@ class Model(object):
         metrics as a hierarchical dictionary.
         """
         # time the prediction
-        starttime = time.time()
+        start_time = time.time()
         y_preds = self.pipeline.predict(X)
+        total = time.time() - start_time
+        self.avg_predict_time = total / float(len(y))
 
+        # TODO: this is hacky. See https://github.com/HDI-Project/ATM/issues/48
         binary = self.num_classes == 2
-        test_scores = test_pipeline(self.pipeline, X, y, binary)
+        kwargs = {}
+        if self.verbose_metrics:
+            kwargs['include_curves'] = True
+            if not binary:
+                kwargs['include_per_class'] = True
 
-        total = time.time() - starttime
-        self.avg_prediction_time = total / float(len(y))
+        # compute the actual test scores!
+        test_scores = test_pipeline(self.pipeline, X, y, binary, **kwargs)
+
+        # save meta-metrics
         self.test_judgment_metric = test_scores.get(self.judgment_metric)
 
         return test_scores

--- a/atm/worker.py
+++ b/atm/worker.py
@@ -62,7 +62,8 @@ class ClassifierError(Exception):
 
 class Worker(object):
     def __init__(self, database, datarun, save_files=True, cloud_mode=False,
-                 aws_config=None, model_dir='models', metric_dir='metrics'):
+                 aws_config=None, model_dir='models', metric_dir='metrics',
+                 verbose_metrics=False):
         """
         database: Database object with connection information
         datarun: Datarun ORM object to work on.
@@ -75,6 +76,7 @@ class Worker(object):
         self.save_files = save_files
         self.cloud_mode = cloud_mode
         self.aws_config = aws_config
+        self.verbose_metrics = verbose_metrics
 
         self.model_dir = model_dir
         self.metric_dir = metric_dir
@@ -330,7 +332,8 @@ class Worker(object):
         """
         model = Model(code=method, params=params,
                       judgment_metric=self.datarun.metric,
-                      label_column=self.dataset.label_column)
+                      label_column=self.dataset.label_column,
+                      verbose_metrics=self.verbose_metrics)
         train_path, test_path = download_data(self.dataset.train_path,
                                               self.dataset.test_path,
                                               self.aws_config)
@@ -413,7 +416,7 @@ class Worker(object):
 
 def work(db, datarun_ids=None, save_files=False, choose_randomly=True,
          cloud_mode=False, aws_config=None, total_time=None, wait=True,
-         model_dir='models', metric_dir='metrics'):
+         model_dir='models', metric_dir='metrics', verbose_metrics=False):
     """
     Check the ModelHub database for unfinished dataruns, and spawn workers to
     work on them as they are added. This process will continue to run until it
@@ -470,7 +473,8 @@ def work(db, datarun_ids=None, save_files=False, choose_randomly=True,
         # actual work happens here
         worker = Worker(db, run, save_files=save_files,
                         cloud_mode=cloud_mode, aws_config=aws_config,
-                        model_dir=model_dir, metric_dir=metric_dir)
+                        model_dir=model_dir, metric_dir=metric_dir,
+                        verbose_metrics=verbose_metrics)
         try:
             worker.run_classifier()
         except ClassifierError as e:
@@ -505,6 +509,9 @@ if __name__ == '__main__':
                         help='Directory where computed models will be saved')
     parser.add_argument('--metric-dir', dest='metric_persist_dir', default='metrics',
                         help='Directory where model metrics will be saved')
+    parser.add_argument('--verbose-metrics', default=False, action='store_true',
+                        help='If set, compute full ROC and PR curves and '
+                        'per-label metrics for each classifier')
 
     # parse arguments and load configuration
     args = parser.parse_args()
@@ -520,4 +527,5 @@ if __name__ == '__main__':
          total_time=args.time,
          wait=False,
          model_dir=args.model_persist_dir,
-         metric_dir=args.metric_persist_dir)
+         metric_dir=args.metric_persist_dir,
+         verbose_metrics=args.verbose_metrics)


### PR DESCRIPTION
This addresses #48, for now, but I think we should eventually incorporate these options into config + the database.
Also:
- fix rank_n_accuracy function and incorporate it by default
- fix some issues with multiclass evaluation that were brought to light by large multiclass dataset
