### PR TITLE
Allow list hyperparameters in method JSON

### DIFF
--- a/atm/__init__.py
+++ b/atm/__init__.py
@@ -1,5 +1,11 @@
-"""An AutoML framework.
+"""Auto Tune Models
+A multi-user, multi-data AutoML framework.
 """
 from __future__ import absolute_import
+import os
+
+# Get the path of the project root, so that the rest of the project can
+# reference files relative to there.
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 
 from . import config, constants, database, enter_data, method, metrics, model, utilities, worker

--- a/atm/config.py
+++ b/atm/config.py
@@ -278,8 +278,13 @@ def add_arguments_datarun(parser):
     #   pa     - passive aggressive
     #   knn    - K nearest neighbors
     #   mlp    - multi-layer perceptron
-    parser.add_argument('--methods', nargs='+', choices=METHODS,
-                        help='list of methods which the datarun will use')
+    parser.add_argument('--methods', nargs='+',
+                        type=option_or_path(METHODS, JSON_REGEX),
+                        help='Method or list of methods to use for '
+                        'classification. Each method can either be one of the '
+                        'pre-defined method codes listed below or a path to a '
+                        'JSON file defining a custom method.' +
+                        '\n\nOptions: [%s]' % ', '.join(str(s) for s in METHODS))
     parser.add_argument('--priority', type=int,
                         help='Priority of the datarun (higher = more important')
     parser.add_argument('--budget-type', choices=BUDGET_TYPES,
@@ -291,13 +296,21 @@ def add_arguments_datarun(parser):
                         'overrides the walltime budget.\nFormat: ' +
                         TIME_FMT.replace('%', '%%'))
 
-    # Which field to use for judgment of performance
+    # Which field to use to judge performance, for the sake of AutoML
     # options:
     #   f1        - F1 score (harmonic mean of precision and recall)
     #   roc_auc   - area under the Receiver Operating Characteristic curve
     #   accuracy  - percent correct
-    #   mu_sigma  - one standard deviation below the average cross-validated F1
-    #               score (mu - sigma)
+    #   cohen_kappa     - measures accuracy, but controls for chance of guessing
+    #                     correctly
+    #   rank_accuracy   - multiclass only: percent of examples for which the true
+    #                     label is in the top 1/3 most likely predicted labels
+    #   ap        - average precision: nearly identical to area under
+    #               precision/recall curve.
+    #   mcc       - matthews correlation coefficient: good for unbalanced classes
+    #
+    # f1 and roc_auc may be appended with _micro or _macro to use with
+    # multiclass problems.
     parser.add_argument('--metric', choices=METRICS,
                         help='Metric by which ATM should evaluate classifiers. '
                         'The metric function specified here will be used to '
@@ -328,7 +341,7 @@ def add_arguments_datarun(parser):
                         help='Type of BTB tuner to use. Can either be one of '
                         'the pre-configured tuners listed below or a path to a '
                         'custom tuner in the form "/path/to/tuner.py:ClassName".'
-                        '\nOptions: [%s]' % ', '.join(str(s) for s in TUNERS))
+                        '\n\nOptions: [%s]' % ', '.join(str(s) for s in TUNERS))
 
     # How should ATM select a particular hyperpartition from the set of all
     # possible hyperpartitions?
@@ -347,7 +360,7 @@ def add_arguments_datarun(parser):
                         help='Type of BTB selector to use. Can either be one of '
                         'the pre-configured selectors listed below or a path to a '
                         'custom tuner in the form "/path/to/selector.py:ClassName".'
-                        '\nOptions: [%s]' % ', '.join(str(s) for s in SELECTORS))
+                        '\n\nOptions: [%s]' % ', '.join(str(s) for s in SELECTORS))
 
     # r_min is the number of random runs performed in each hyperpartition before
     # allowing bayesian opt to select parameters. Consult the thesis to

--- a/atm/constants.py
+++ b/atm/constants.py
@@ -1,3 +1,5 @@
+import os
+from atm import PROJECT_ROOT
 # sample tuners
 from btb.tuning import Uniform as UniformTuner, GP, GPEi, GPEiVelocity
 # hyperpartition selectors
@@ -21,9 +23,12 @@ CLASSIFIER_STATUS = ['running', 'errored', 'complete']
 PARTITION_STATUS = ['incomplete', 'errored', 'gridding_done']
 
 TIME_FMT = '%Y-%m-%d %H:%M'
-DATA_PATH = 'data/downloads'
+DATA_DL_PATH = os.path.join(PROJECT_ROOT, 'data/downloads')
+METHOD_PATH = os.path.join(PROJECT_ROOT, 'methods')
+LOG_PATH = os.path.join(PROJECT_ROOT, 'logs')
 
 CUSTOM_CLASS_REGEX = '(.*\.py):(\w+)$'
+JSON_REGEX = '(.*\.json)$'
 
 TUNERS_MAP = {
     'uniform': UniformTuner,

--- a/atm/database.py
+++ b/atm/database.py
@@ -168,7 +168,7 @@ class Database(object):
             datarun = relationship('Datarun', back_populates='hyperpartitions')
 
             # these columns define the partition
-            method = Column(String(15))
+            method = Column(String(255))
             categoricals64 = Column(Text)
             tunables64 = Column(Text)
             constants64 = Column(Text)

--- a/atm/enter_data.py
+++ b/atm/enter_data.py
@@ -137,7 +137,7 @@ def enter_datarun(sql_config, run_config, aws_config=None,
     method_parts = {}
     for m in run_config.methods:
         # enumerate all combinations of categorical variables for this method
-        method = Method(METHODS_MAP[m])
+        method = Method(m)
         method_parts[m] = method.get_hyperpartitions()
         print('method', m, 'has', len(method_parts[m]), 'hyperpartitions')
 

--- a/atm/method.py
+++ b/atm/method.py
@@ -48,9 +48,9 @@ class Categorical(HyperParameter):
 
 
 class List(HyperParameter):
-    def __init__(self, name, type, sizes, element):
+    def __init__(self, name, type, list_length, element):
         self.name = name
-        self.size = Categorical(self.name + '_size', 'int_cat', sizes)
+        self.size = Categorical('len(%s)' % self.name, 'int_cat', list_length)
         element_type = HYPERPARAMETER_TYPES[element['type']]
         self.element = element_type('element', **element)
 
@@ -122,14 +122,14 @@ class Method(object):
             config = json.load(f)
 
         self.name = config['name']
-        self.conditions = config['conditions']
-        self.root_params = config['root_parameters']
+        self.root_params = config['root_hyperparameters']
+        self.conditions = config['conditional_hyperparameters']
         self.class_path = config['class']
 
         # create hyperparameters from the parameter config
         self.parameters = {}
         lists = []
-        for k, v in config['parameters'].items():
+        for k, v in config['hyperparameters'].items():
             param_type = HYPERPARAMETER_TYPES[v['type']]
             self.parameters[k] = param_type(name=k, **v)
 

--- a/atm/method.py
+++ b/atm/method.py
@@ -1,3 +1,5 @@
+from builtins import object, str as newstr
+
 import json
 from os.path import join
 
@@ -33,6 +35,20 @@ class Categorical(HyperParameter):
     def __init__(self, name, type, values):
         self.name = name
         self.type = type
+        for i, val in enumerate(values):
+            if val is None:
+                # the value None is allowed for every parameter type
+                continue
+            if self.type == 'int_cat':
+                values[i] = int(val)
+            elif self.type == 'float_cat':
+                values[i] = float(val)
+            elif self.type == 'string':
+                # this is necessary to avoid a bug in sklearn, which won't be
+                # fixed until 0.20
+                values[i] = str(newstr(val))
+            elif self.type == 'bool':
+                values[i] = bool(val)
         self.values = values
 
     @property

--- a/atm/model.py
+++ b/atm/model.py
@@ -235,7 +235,7 @@ class Model(object):
 
         for lname, items in lists.items():
             # drop the list size parameter
-            del params[lname + '_size']
+            del params['len(%s)' % lname]
 
             # sort the list by index
             params[lname] = [val for idx, val in sorted(items)]

--- a/atm/model.py
+++ b/atm/model.py
@@ -46,25 +46,26 @@ class Model(object):
     # number of folds for cross-validation (arbitrary, for speed)
     N_FOLDS = 5
 
-    def __init__(self, code, params, judgment_metric, label_column,
+    def __init__(self, method, params, judgment_metric, label_column,
                  testing_ratio=0.3):
         """
         Parameters:
-            code: the short method code (as defined in constants.py)
+            method: the short method code (as defined in constants.py) or path
+                to method json
             judgment_metric: string that indicates which metric should be
                 optimized for.
             params: parameters passed to the sklearn classifier constructor
             class_: sklearn classifier class
         """
         # configuration & database
-        self.code = code
+        self.method = method
         self.params = params
         self.judgment_metric = judgment_metric
         self.label_column = label_column
         self.testing_ratio = testing_ratio
 
         # load the classifier method's class
-        path = Method(METHODS_MAP[code]).class_path.split('.')
+        path = Method(method).class_path.split('.')
         mod_str, cls_str = '.'.join(path[:-1]), path[-1]
         mod = import_module(mod_str)
         self.class_ = getattr(mod, cls_str)
@@ -124,7 +125,7 @@ class Model(object):
             steps.append(('minmax_scale', MinMaxScaler()))
 
         # add the classifier as the final step in the pipeline
-        steps.append((self.code, classifier))
+        steps.append((self.method, classifier))
         self.pipeline = Pipeline(steps)
 
     def cross_validate(self, X, y):
@@ -240,7 +241,7 @@ class Model(object):
             params[lname] = [val for idx, val in sorted(items)]
 
         ## Gaussian process classifier
-        if self.code == "gp":
+        if self.method == "gp":
             if params["kernel"] == "constant":
                 params["kernel"] = ConstantKernel()
             elif params["kernel"] == "rbf":

--- a/atm/utilities.py
+++ b/atm/utilities.py
@@ -228,17 +228,17 @@ def get_local_data_path(data_path):
     if m:
         path = data_path[len(m.group()):].split('/')
         bucket = path.pop(0)
-        return os.path.join(DATA_PATH, path[-1]), FileType.S3
+        return os.path.join(DATA_DL_PATH, path[-1]), FileType.S3
 
     m = re.match(HTTP_PREFIX, data_path)
     if m:
         path = data_path[len(m.group()):].split('/')
-        return os.path.join(DATA_PATH, path[-1]), FileType.HTTP
+        return os.path.join(DATA_DL_PATH, path[-1]), FileType.HTTP
 
     return data_path, FileType.LOCAL
 
 
-def download_file_s3(aws_path, aws_config, local_folder=DATA_PATH):
+def download_file_s3(aws_path, aws_config, local_folder=DATA_DL_PATH):
     """ Download a file from an S3 bucket and save it in the local folder. """
     # remove the prefix and extract the S3 bucket, folder, and file name
     m = re.match(S3_PREFIX, aws_path)
@@ -274,7 +274,7 @@ def download_file_s3(aws_path, aws_config, local_folder=DATA_PATH):
     return path
 
 
-def download_file_http(url, local_folder=DATA_PATH):
+def download_file_http(url, local_folder=DATA_DL_PATH):
     """ Download a file from a public URL and save it locally. """
     filename = url.split('/')[-1]
     if local_folder is not None:

--- a/atm/worker.py
+++ b/atm/worker.py
@@ -35,12 +35,14 @@ warnings.filterwarnings('ignore')
 os.environ['GNUMPY_IMPLICIT_CONVERSION'] = 'allow'
 
 # get the file system in order
+DEFAULT_MODEL_DIR = os.path.join(PROJECT_ROOT, 'models')
+DEFAULT_METRIC_DIR = os.path.join(PROJECT_ROOT, 'metrics')
+
 # make sure we have directories where we need them
-LOG_DIR = 'logs'
-ensure_directory(LOG_DIR)
+ensure_directory(LOG_PATH)
 
 # name log file after the local hostname
-LOG_FILE = os.path.join(LOG_DIR, '%s.txt' % socket.gethostname())
+LOG_FILE = os.path.join(LOG_PATH, '%s.txt' % socket.gethostname())
 
 # how long to sleep between loops while waiting for new dataruns to be added
 LOOP_WAIT = 1
@@ -62,7 +64,8 @@ class ClassifierError(Exception):
 
 class Worker(object):
     def __init__(self, database, datarun, save_files=True, cloud_mode=False,
-                 aws_config=None, model_dir='models', metric_dir='metrics'):
+                 aws_config=None, model_dir=DEFAULT_MODEL_DIR,
+                 metric_dir=DEFAULT_METRIC_DIR):
         """
         database: Database object with connection information
         datarun: Datarun ORM object to work on.
@@ -328,7 +331,7 @@ class Worker(object):
         classification model.
         Returns: Model object and metrics dictionary
         """
-        model = Model(code=method, params=params,
+        model = Model(method=method, params=params,
                       judgment_metric=self.datarun.metric,
                       label_column=self.dataset.label_column)
         train_path, test_path = download_data(self.dataset.train_path,
@@ -388,7 +391,7 @@ class Worker(object):
                  hyperpartition.id)
             return
 
-        _log('Chose parameters for method %s:' % hyperpartition.method)
+        _log('Chose parameters for method "%s":' % hyperpartition.method)
         for k in sorted(params.keys()):
             _log('\t%s = %s' % (k, params[k]))
 
@@ -501,9 +504,11 @@ if __name__ == '__main__':
     parser.add_argument('--no-save', dest='save_files', default=True,
                         action='store_const', const=False,
                         help="don't save models and metrics for later")
-    parser.add_argument('--model-dir', dest='model_persist_dir', default='models',
+    parser.add_argument('--model-dir', dest='model_persist_dir',
+                        default=DEFAULT_MODEL_DIR,
                         help='Directory where computed models will be saved')
-    parser.add_argument('--metric-dir', dest='metric_persist_dir', default='metrics',
+    parser.add_argument('--metric-dir', dest='metric_persist_dir',
+                        default=DEFAULT_METRIC_DIR,
                         help='Directory where model metrics will be saved')
 
     # parse arguments and load configuration

--- a/atm/worker.py
+++ b/atm/worker.py
@@ -385,8 +385,8 @@ class Worker(object):
             return
 
         _log('Chose parameters for method %s:' % hyperpartition.method)
-        for k, v in params.items():
-            _log('\t%s = %s' % (k, v))
+        for k in sorted(params.keys()):
+            _log('\t%s = %s' % (k, params[k]))
 
         _log('Creating classifier...')
         classifier = self.db.create_classifier(hyperpartition_id=hyperpartition.id,

--- a/methods/adaboost.json
+++ b/methods/adaboost.json
@@ -1,7 +1,7 @@
 {   
     "name": "ada",
     "class": "sklearn.ensemble.AdaBoostClassifier",
-    "parameters": {
+    "hyperparameters": {
         "n_estimators": {
             "type": "int",
             "range": [25, 500]
@@ -11,6 +11,6 @@
             "range": [0.5, 10]
         }
     },
-    "root_parameters": ["n_estimators", "learning_rate"],
-    "conditions": {}
+    "root_hyperparameters": ["n_estimators", "learning_rate"],
+    "conditional_hyperparameters": {}
 }

--- a/methods/adaboost.json
+++ b/methods/adaboost.json
@@ -4,11 +4,11 @@
     "parameters": {
         "n_estimators": {
            "type": "int",
-           "range": [25,500]
+           "range": [25, 500]
         },
         "learning_rate": {
            "type": "float",
-           "range": [0.5,10]
+           "range": [0.5, 10]
         }
     },
     "root_parameters": ["n_estimators", "learning_rate"],

--- a/methods/bernoulli_naive_bayes.json
+++ b/methods/bernoulli_naive_bayes.json
@@ -16,11 +16,11 @@
         },
         "class_prior": {
            "type": "string",
-           "range": [null]
+           "values": [null]
         },
         "_scale": {
            "type": "bool",
-           "range": [true]
+           "values": [true]
         }
     },
     "root_parameters": ["alpha", "binarize", "fit_prior", "class_prior", "_scale"],

--- a/methods/bernoulli_naive_bayes.json
+++ b/methods/bernoulli_naive_bayes.json
@@ -1,7 +1,7 @@
 {   
     "name": "bnb",
     "class": "sklearn.naive_bayes.BernoulliNB",
-    "parameters": {
+    "hyperparameters": {
         "alpha": {
             "type": "float",
             "range": [0.0, 1.0]
@@ -23,6 +23,6 @@
             "values": [true]
         }
     },
-    "root_parameters": ["alpha", "binarize", "fit_prior", "class_prior", "_scale"],
-    "conditions": {}
+    "root_hyperparameters": ["alpha", "binarize", "fit_prior", "class_prior", "_scale"],
+    "conditional_hyperparameters": {}
 }

--- a/methods/decision_tree.json
+++ b/methods/decision_tree.json
@@ -1,7 +1,7 @@
 {   
     "name": "dt",
     "class": "sklearn.tree.DecisionTreeClassifier",
-    "parameters": {
+    "hyperparameters": {
         "criterion": {
             "type": "string",
             "values": ["entropy", "gini"]
@@ -23,6 +23,6 @@
             "range": [1, 3]
         }
     },
-    "root_parameters": ["criterion", "max_features", "max_depth", "min_samples_split", "min_samples_leaf"],
-    "conditions": {}
+    "root_hyperparameters": ["criterion", "max_features", "max_depth", "min_samples_split", "min_samples_leaf"],
+    "conditional_hyperparameters": {}
 }

--- a/methods/decision_tree.json
+++ b/methods/decision_tree.json
@@ -4,7 +4,7 @@
     "parameters": {
         "criterion": {
             "type": "string",
-            "range": ["entropy", "gini"]
+            "values": ["entropy", "gini"]
         },
         "max_features": {
             "type": "float",

--- a/methods/extra_trees.json
+++ b/methods/extra_trees.json
@@ -4,7 +4,7 @@
     "parameters": {
         "criterion": {
             "type": "string",
-            "range": ["entropy", "gini"]
+            "values": ["entropy", "gini"]
         },
         "max_features": {
             "type": "float",
@@ -24,7 +24,7 @@
         },
         "n_estimators": {
            "type": "int_cat",
-           "range": [100]
+           "values": [100]
         },
         "n_jobs": {
            "type": "int",

--- a/methods/extra_trees.json
+++ b/methods/extra_trees.json
@@ -1,7 +1,7 @@
 {   
     "name": "et",
     "class": "sklearn.ensemble.ExtraTreesClassifier",
-    "parameters": {
+    "hyperparameters": {
         "criterion": {
             "type": "string",
             "values": ["entropy", "gini"]
@@ -31,6 +31,6 @@
             "range": [-1]
         }
     },
-    "root_parameters": ["criterion", "max_features", "max_depth", "min_samples_leaf", "min_samples_leaf", "n_estimators", "n_jobs"],
-    "conditions": {}
+    "root_hyperparameters": ["criterion", "max_features", "max_depth", "min_samples_leaf", "min_samples_leaf", "n_estimators", "n_jobs"],
+    "conditional_hyperparameters": {}
 }

--- a/methods/gaussian_naive_bayes.json
+++ b/methods/gaussian_naive_bayes.json
@@ -1,12 +1,12 @@
 {   
     "name": "gnb",
     "class": "sklearn.naive_bayes.GaussianNB",
-    "parameters": {
+    "hyperparameters": {
         "_scale_minmax": {
             "type": "bool",
             "values": [true]
         }
     },
-    "root_parameters": ["_scale_minmax"],
-    "conditions": {}
+    "root_hyperparameters": ["_scale_minmax"],
+    "conditional_hyperparameters": {}
 }

--- a/methods/gaussian_naive_bayes.json
+++ b/methods/gaussian_naive_bayes.json
@@ -4,7 +4,7 @@
     "parameters": {
         "_scale_minmax": {
             "type": "bool",
-            "range": [true]
+            "values": [true]
         }
     },
     "root_parameters": ["_scale_minmax"],

--- a/methods/gaussian_process.json
+++ b/methods/gaussian_process.json
@@ -1,7 +1,7 @@
 {   
     "name": "gp",
     "class": "sklearn.gaussian_process.GaussianProcessClassifier",
-    "parameters": {
+    "hyperparameters": {
         "kernel": {
             "type": "string",
             "values": ["constant", "rbf", "matern", "rational_quadratic", "exp_sine_squared"]
@@ -23,8 +23,8 @@
             "values": [0, 1]
         }
     },
-    "root_parameters": ["kernel"],
-    "conditions": {
+    "root_hyperparameters": ["kernel"],
+    "conditional_hyperparameters": {
         "kernel": {
             "matern": ["nu"],
             "rational_quadratic": ["length_scale", "alpha"],

--- a/methods/gaussian_process.json
+++ b/methods/gaussian_process.json
@@ -4,11 +4,11 @@
     "parameters": {
         "kernel": {
             "type": "string",
-            "range": ["constant", "rbf", "matern", "rational_quadratic", "exp_sine_squared"]
+            "values": ["constant", "rbf", "matern", "rational_quadratic", "exp_sine_squared"]
         },
         "nu": {
             "type": "float_cat",
-            "range": [0.5, 1.5, 2.5]
+            "values": [0.5, 1.5, 2.5]
         },
         "length_scale": {
            "type": "float_exp",
@@ -20,7 +20,7 @@
         },
         "periodicity": {
            "type": "int_cat",
-           "range": [0, 1]
+           "values": [0, 1]
         }
     },
     "root_parameters": ["kernel"],

--- a/methods/k_nearest_neighbors.json
+++ b/methods/k_nearest_neighbors.json
@@ -1,7 +1,7 @@
 {   
     "name": "knn",
     "class": "sklearn.neighbors.KNeighborsClassifier",
-    "parameters": {
+    "hyperparameters": {
         "n_neighbors": {
             "type": "int",
             "range": [1, 20]
@@ -31,8 +31,8 @@
             "values": [true]
         }
     },
-    "root_parameters": ["n_neighbors", "weights", "algorithm", "metric", "_scale"],
-    "conditions": {
+    "root_hyperparameters": ["n_neighbors", "weights", "algorithm", "metric", "_scale"],
+    "conditional_hyperparameters": {
         "metric": {
             "minkowski": ["p"]
         },

--- a/methods/k_nearest_neighbors.json
+++ b/methods/k_nearest_neighbors.json
@@ -8,11 +8,11 @@
         },
         "weights": {
            "type": "string",
-           "range": ["uniform", "distance"]
+           "values": ["uniform", "distance"]
         },
         "algorithm": {
            "type": "string",
-           "range": ["ball_tree", "kd_tree", "brute"]
+           "values": ["ball_tree", "kd_tree", "brute"]
         },
         "leaf_size": {
            "type": "int",
@@ -20,7 +20,7 @@
         },
         "metric": {
             "type": "string",
-            "range": ["minkowski", "euclidean", "manhattan", "chebyshev"]
+            "values": ["minkowski", "euclidean", "manhattan", "chebyshev"]
         },
         "p": {
            "type": "int",
@@ -28,7 +28,7 @@
         },
         "_scale": {
            "type": "bool",
-           "range": [true]
+           "values": [true]
         }
     },
     "root_parameters": ["n_neighbors", "weights", "algorithm", "metric", "_scale"],

--- a/methods/logistic_regression.json
+++ b/methods/logistic_regression.json
@@ -1,7 +1,7 @@
 {   
     "name": "logreg",
     "class": "sklearn.linear_model.LogisticRegression",
-    "parameters": {
+    "hyperparameters": {
         "C": {
             "type": "float_exp",
             "range": [1e-5, 1e5]
@@ -31,8 +31,8 @@
             "values": [true]
         }
     },
-    "root_parameters": ["C", "tol", "penalty", "fit_intercept", "class_weight", "_scale"],
-    "conditions": {
+    "root_hyperparameters": ["C", "tol", "penalty", "fit_intercept", "class_weight", "_scale"],
+    "conditional_hyperparameters": {
         "penalty": {
             "l2": ["dual"]
         }

--- a/methods/logistic_regression.json
+++ b/methods/logistic_regression.json
@@ -12,23 +12,23 @@
         },
         "penalty": {
            "type": "string",
-           "range": ["l1", "l2"]
+           "values": ["l1", "l2"]
         },
         "dual": {
            "type": "bool",
-           "range": [true, false]
+           "values": [true, false]
         },
         "fit_intercept": {
             "type": "bool",
-            "range": [true, false]
+            "values": [true, false]
         },
         "class_weight": {
            "type": "string",
-           "range": ["auto"]
+           "values": ["auto"]
         },
         "_scale": {
            "type": "bool",
-           "range": [true]
+           "values": [true]
         }
     },
     "root_parameters": ["C", "tol", "penalty", "fit_intercept", "class_weight", "_scale"],

--- a/methods/multi_layer_perceptron.json
+++ b/methods/multi_layer_perceptron.json
@@ -4,31 +4,15 @@
     "parameters": {
         "batch_size": {
            "type": "string",
-           "range": ["auto"]
+           "values": ["auto"]
         },
         "solver": {
            "type": "string",
-           "range": ["lbfgs", "sgd", "adam"]
+           "values": ["lbfgs", "sgd", "adam"]
         },
         "alpha": {
            "type": "float",
            "range": [0.0001, 0.009]
-        },
-        "num_hidden_layers": {
-           "type": "int_cat",
-           "range": [1, 2, 3]
-        },
-        "hidden_size_layer1": {
-            "type": "int",
-            "range": [2, 300]
-        },
-        "hidden_size_layer2": {
-            "type": "int",
-            "range": [2, 300]
-        },
-        "hidden_size_layer3": {
-            "type": "int",
-            "range": [2, 300]
         },
         "learning_rate_init": {
            "type": "float",
@@ -44,24 +28,27 @@
         },
         "learning_rate": {
            "type": "string",
-           "range": ["constant", "invscaling", "adaptive"]
+           "values": ["constant", "invscaling", "adaptive"]
         },
         "activation": {
            "type": "string",
-           "range": ["relu", "logistic", "identity", "tanh"]
+           "values": ["relu", "logistic", "identity", "tanh"]
+        },
+        "hidden_layer_sizes": {
+            "type": "list",
+            "sizes": [1, 2, 3],
+            "element": {
+                "type": "int",
+                "range": [2, 300]
+            }
         },
         "_scale": {
            "type": "string",
-           "range": [true]
+           "values": [true]
         }
     },
-    "root_parameters": ["batch_size", "solver", "alpha", "activation", "num_hidden_layers", "_scale"],
+    "root_parameters": ["batch_size", "solver", "alpha", "activation", "hidden_layer_sizes", "_scale"],
     "conditions": {
-        "num_hidden_layers": {
-            "1": ["hidden_size_layer1"],
-            "2": ["hidden_size_layer1", "hidden_size_layer2"],
-            "3": ["hidden_size_layer1", "hidden_size_layer2", "hidden_size_layer3"]
-        },
         "solver": {
             "sgd": ["learning_rate_init", "learning_rate"],
             "adam": ["learning_rate_init", "beta_1", "beta_2"]

--- a/methods/multi_layer_perceptron.json
+++ b/methods/multi_layer_perceptron.json
@@ -1,7 +1,7 @@
 {   
     "name": "mlp",
     "class": "sklearn.neural_network.MLPClassifier",
-    "parameters": {
+    "hyperparameters": {
         "batch_size": {
             "type": "string",
             "values": ["auto"]
@@ -36,7 +36,7 @@
         },
         "hidden_layer_sizes": {
             "type": "list",
-            "sizes": [1, 2, 3],
+            "list_length": [1, 2, 3],
             "element": {
                 "type": "int",
                 "range": [2, 300]
@@ -47,8 +47,8 @@
             "values": [true]
         }
     },
-    "root_parameters": ["batch_size", "solver", "alpha", "activation", "hidden_layer_sizes", "_scale"],
-    "conditions": {
+    "root_hyperparameters": ["batch_size", "solver", "alpha", "activation", "hidden_layer_sizes", "_scale"],
+    "conditional_hyperparameters": {
         "solver": {
             "sgd": ["learning_rate_init", "learning_rate"],
             "adam": ["learning_rate_init", "beta_1", "beta_2"]

--- a/methods/multinomial_naive_bayes.json
+++ b/methods/multinomial_naive_bayes.json
@@ -12,11 +12,11 @@
         },
         "class_prior": {
            "type": "string",
-           "range": [null]
+           "values": [null]
         },
         "_scale_minmax": {
            "type": "bool",
-           "range": [true]
+           "values": [true]
         }
     },
     "root_parameters": ["alpha", "fit_prior", "class_prior", "_scale_minmax"],

--- a/methods/multinomial_naive_bayes.json
+++ b/methods/multinomial_naive_bayes.json
@@ -1,7 +1,7 @@
 {   
     "name": "mnb",
     "class": "sklearn.naive_bayes.MultinomialNB",
-    "parameters": {
+    "hyperparameters": {
         "alpha": {
             "type": "float",
             "range": [0.0, 1.0]
@@ -19,6 +19,6 @@
             "values": [true]
         }
     },
-    "root_parameters": ["alpha", "fit_prior", "class_prior", "_scale_minmax"],
-    "conditions": {}
+    "root_hyperparameters": ["alpha", "fit_prior", "class_prior", "_scale_minmax"],
+    "conditional_hyperparameters": {}
 }

--- a/methods/passive_aggressive.json
+++ b/methods/passive_aggressive.json
@@ -8,7 +8,7 @@
         },
         "fit_intercept": {
            "type": "int_cat",
-           "range": [0, 1]
+           "values": [0, 1]
         },
         "n_iter": {
            "type": "int",
@@ -16,19 +16,19 @@
         },
         "shuffle": {
            "type": "bool",
-           "range": [true]
+           "values": [true]
         },
         "loss": {
             "type": "string",
-            "range": ["hinge", "squared_hinge"]
+            "values": ["hinge", "squared_hinge"]
         },
         "_scale": {
            "type": "bool",
-           "range": [true]
+           "values": [true]
         },
         "n_jobs": {
            "type": "int_cat",
-           "range": [-1]
+           "values": [-1]
         }
     },
     "root_parameters": ["C", "fit_intercept", "n_iter", "shuffle", "loss", "_scale", "n_jobs"],

--- a/methods/passive_aggressive.json
+++ b/methods/passive_aggressive.json
@@ -1,7 +1,7 @@
 {   
     "name": "pa",
     "class": "sklearn.linear_model.PassiveAggressiveClassifier",
-    "parameters": {
+    "hyperparameters": {
         "C": {
             "type": "float_exp",
             "range": [1e-5, 1e5]
@@ -31,6 +31,6 @@
             "values": [-1]
         }
     },
-    "root_parameters": ["C", "fit_intercept", "n_iter", "shuffle", "loss", "_scale", "n_jobs"],
-    "conditions": {}
+    "root_hyperparameters": ["C", "fit_intercept", "n_iter", "shuffle", "loss", "_scale", "n_jobs"],
+    "conditional_hyperparameters": {}
 }

--- a/methods/random_forest.json
+++ b/methods/random_forest.json
@@ -4,7 +4,7 @@
     "parameters": {
         "criterion": {
             "type": "string",
-            "range": ["entropy", "gini"]
+            "values": ["entropy", "gini"]
         },
         "max_features": {
             "type": "float",
@@ -24,11 +24,11 @@
         },
         "n_estimators": {
            "type": "int_cat",
-           "range": [100]
+           "values": [100]
         },
         "n_jobs": {
            "type": "int_cat",
-           "range": [-1]
+           "values": [-1]
         }
     },
     "root_parameters": ["criterion", "max_features", "max_depth", "min_samples_leaf", "min_samples_leaf", "n_estimators", "n_jobs"],

--- a/methods/random_forest.json
+++ b/methods/random_forest.json
@@ -1,7 +1,7 @@
 {   
     "name": "rf",
     "class": "sklearn.ensemble.RandomForestClassifier",
-    "parameters": {
+    "hyperparameters": {
         "criterion": {
             "type": "string",
             "values": ["entropy", "gini"]
@@ -31,6 +31,6 @@
             "values": [-1]
         }
     },
-    "root_parameters": ["criterion", "max_features", "max_depth", "min_samples_leaf", "min_samples_leaf", "n_estimators", "n_jobs"],
-    "conditions": {}
+    "root_hyperparameters": ["criterion", "max_features", "max_depth", "min_samples_leaf", "min_samples_leaf", "n_estimators", "n_jobs"],
+    "conditional_hyperparameters": {}
 }

--- a/methods/stochastic_gradient_descent.json
+++ b/methods/stochastic_gradient_descent.json
@@ -19,7 +19,7 @@
             "range": [0.0, 1.0]
         },
         "fit_intercept": {
-            "type": "int_cat",
+            "type": "int",
             "range": [0, 1]
         },
         "n_iter": {

--- a/methods/stochastic_gradient_descent.json
+++ b/methods/stochastic_gradient_descent.json
@@ -4,11 +4,11 @@
     "parameters": {
         "loss": {
             "type": "string",
-            "range": ["hinge", "log", "modified_huber", "squared_hinge"]
+            "values": ["hinge", "log", "modified_huber", "squared_hinge"]
         },
         "penalty": {
             "type": "string",
-            "range": ["l1", "l2", "elasticnet"]
+            "values": ["l1", "l2", "elasticnet"]
         },
         "alpha": {
            "type": "float_exp",
@@ -28,7 +28,7 @@
         },
         "shuffle": {
            "type": "bool",
-           "range": [true]
+           "values": [true]
         },
         "epsilon": {
            "type": "float_exp",
@@ -36,7 +36,7 @@
         },
         "learning_rate": {
            "type": "string",
-           "range": ["constant", "optimal"]
+           "values": ["constant", "optimal"]
         },
         "eta0": {
            "type": "float_exp",
@@ -44,15 +44,15 @@
         },
         "class_weight": {
            "type": "string",
-           "range": [null]
+           "values": [null]
         },
         "_scale_minmax": {
            "type": "bool",
-           "range": [true]
+           "values": [true]
         },
         "n_jobs": {
            "type": "int_cat",
-           "range": [-1]
+           "values": [-1]
         }
     },
     "root_parameters": ["loss", "penalty", "alpha", "l1_ratio", "fit_intercept", "n_iter", "shuffle", "epsilon", "learning_rate", "eta0", "class_weight", "_scale_minmax", "n_jobs"],

--- a/methods/stochastic_gradient_descent.json
+++ b/methods/stochastic_gradient_descent.json
@@ -1,7 +1,7 @@
 {   
     "name": "sgd",
     "class": "sklearn.linear_model.SGDClassifier",
-    "parameters": {
+    "hyperparameters": {
         "loss": {
             "type": "string",
             "values": ["hinge", "log", "modified_huber", "squared_hinge"]
@@ -55,6 +55,6 @@
             "values": [-1]
         }
     },
-    "root_parameters": ["loss", "penalty", "alpha", "l1_ratio", "fit_intercept", "n_iter", "shuffle", "epsilon", "learning_rate", "eta0", "class_weight", "_scale_minmax", "n_jobs"],
-    "conditions": {}
+    "root_hyperparameters": ["loss", "penalty", "alpha", "l1_ratio", "fit_intercept", "n_iter", "shuffle", "epsilon", "learning_rate", "eta0", "class_weight", "_scale_minmax", "n_jobs"],
+    "conditional_hyperparameters": {}
 }

--- a/methods/support_vector_machine.json
+++ b/methods/support_vector_machine.json
@@ -36,7 +36,7 @@
         },
         "class_weight": {
             "type": "string",
-            "range": ["balanced"]
+            "values": ["balanced"]
         },
         "_scale": {
             "type": "bool",

--- a/methods/support_vector_machine.json
+++ b/methods/support_vector_machine.json
@@ -12,7 +12,7 @@
         },
         "kernel": {
            "type": "string",
-           "range": ["rbf", "poly", "linear", "sigmoid"]
+           "values": ["rbf", "poly", "linear", "sigmoid"]
         },
         "degree": {
            "type": "int",
@@ -24,11 +24,11 @@
         },
         "probability": {
             "type": "bool",
-            "range": [true]
+            "values": [true]
         },
         "shrinking": {
             "type": "bool",
-            "range": [true]
+            "values": [true]
         },
         "cache_size": {
            "type": "int",
@@ -36,11 +36,11 @@
         },
         "class_weight": {
            "type": "string",
-           "range": ["auto"]
+           "values": ["auto"]
         },
         "_scale": {
            "type": "bool",
-           "range": [true]
+           "values": [true]
         },
         "max_iter": {
            "type": "int",

--- a/methods/support_vector_machine.json
+++ b/methods/support_vector_machine.json
@@ -1,7 +1,7 @@
 {   
     "name": "svm",
     "class": "sklearn.svm.SVC",
-    "parameters": {
+    "hyperparameters": {
         "C": {
             "type": "float_exp",
             "range": [1e-5, 1e5]
@@ -47,8 +47,8 @@
             "range": [50000]
         }
     },
-    "root_parameters": ["C", "kernel", "probability", "shrinking", "cache_size", "class_weight", "max_iter", "_scale"],
-    "conditions": {
+    "root_hyperparameters": ["C", "kernel", "probability", "shrinking", "cache_size", "class_weight", "max_iter", "_scale"],
+    "conditional_hyperparameters": {
         "kernel": {
             "rbf": ["gamma"],
             "sigmoid": ["gamma", "coef0"],

--- a/test/btb_test.py
+++ b/test/btb_test.py
@@ -4,6 +4,7 @@ import os
 import random
 from os.path import join
 
+from atm import PROJECT_ROOT
 from atm.config import *
 from atm.database import Database
 from atm.enter_data import enter_datarun
@@ -11,7 +12,7 @@ from atm.enter_data import enter_datarun
 from utilities import *
 
 
-CONF_DIR = 'config/test/btb/'
+CONF_DIR = os.path.join(PROJECT_ROOT, 'config/test/btb/')
 RUN_CONFIG = join(CONF_DIR, 'run.yaml')
 SQL_CONFIG = join(CONF_DIR, 'sql.yaml')
 

--- a/test/end_to_end_test.py
+++ b/test/end_to_end_test.py
@@ -15,8 +15,8 @@ from atm.worker import work
 from utilities import *
 
 
-CONF_DIR = 'config/test/end_to_end/'
-DATA_DIR = 'data/test/'
+CONF_DIR = os.path.join(PROJECT_ROOT, 'config/test/end_to_end/')
+DATA_DIR = os.path.join(PROJECT_ROOT, 'data/test/')
 RUN_CONFIG = join(CONF_DIR, 'run.yaml')
 SQL_CONFIG = join(CONF_DIR, 'sql.yaml')
 

--- a/test/method_test.py
+++ b/test/method_test.py
@@ -15,8 +15,8 @@ from atm.worker import work
 from utilities import *
 
 
-CONF_DIR = 'config/test/method/'
-DATA_DIR = 'data/test/'
+CONF_DIR = os.path.join(PROJECT_ROOT, 'config/test/method/')
+DATA_DIR = os.path.join(PROJECT_ROOT, 'data/test/')
 RUN_CONFIG = join(CONF_DIR, 'run.yaml')
 SQL_CONFIG = join(CONF_DIR, 'sql.yaml')
 DATASETS = [

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     plt = None
 
-BASELINE_PATH = 'test/baselines/best_so_far/'
+BASELINE_PATH = os.path.join(PROJECT_ROOT, 'test/baselines/best_so_far/')
 DATA_URL = 'https://s3.amazonaws.com/mit-dai-delphi-datastore/downloaded/'
 BASELINE_URL = 'https://s3.amazonaws.com/mit-dai-delphi-datastore/best_so_far/'
 


### PR DESCRIPTION
First, this PR moves a lot of hyperparameter logic from BTB to ATM. Specifically, all conditional hyperparameters are handled on the ATM side now. Categorical hyperparameters will remain in BTB, but the BTB categoricals will not be relevant to ATM anymore.

The bigger change is the addition of List hyperparameters: you can now add a single hyperparameter that represents a list of many hyperparameters of the same type and range. For example, in `multi_layer_perceptron.json`:  

```
        "hidden_layer_sizes": {
            "type": "list",
            "sizes": [1, 2, 3],
            "element": {
                "type": "int",
                "range": [2, 300]
            }
        },
```
Lists need to be defined with caution. Behind the scenes, the list is translated to a single "size" hyperparameter along with a list of "element" hyperparameters conditioned on every possible value of "size". For example, the above code would define the following hyperpartitions:
```
hidden_layer_sizes_size = 1
  hidden_layer_sizes[0] = ?

hidden_layer_sizes_size = 2
  hidden_layer_sizes[0] = ?
  hidden_layer_sizes[1] = ?

hidden_layer_sizes_size = 3
  hidden_layer_sizes[0] = ?
  hidden_layer_sizes[1] = ?
  hidden_layer_sizes[2] = ?
```
Note that `"sizes"` must be defined as a _list of possible values_, not a range. This should make it harder to accidentally create O(n<sup>2</sup>) conditional hyperparameters by defining a list with a huge range.

Finally, categorical hyperparameters are now defined with a list of `"values"` instead of a `"range"`. This is meant to make it less confusing when defining `int` or `int_cat` parameters. For example:
```
"param_a": {
    "type": "int_cat",
    "values": [1, 3]         # Only includes the values 1 and 3
},
```
is different from
```
"param_b": {
    "type": "int",
    "range": [1, 3]         # Includes the values 1, 2, and 3
},
```