### PR TITLE
adding fix for renaming classifier object property

### DIFF
--- a/atm/utilities.py
+++ b/atm/utilities.py
@@ -181,7 +181,7 @@ def make_save_path(dir, classifier, suffix):
     """
     run_name = "".join([c for c in classifier.datarun.dataset.name
                         if c.isalnum() or c in (' ', '-', '_')]).rstrip()
-    params_hash = hash_dict(classifier.params)[:8]
+    params_hash = hash_dict(classifier.hyperparameter_values)[:8]
     filename = "%s-%s.%s" % (run_name, params_hash, suffix)
     return os.path.join(dir, filename)
 


### PR DESCRIPTION
In commit fa603107ce7d459658ab70c6eccc8750af738302   ... params was renamed to hyperparameter_values.  The commit log shows:

>     params -> hyperparameter_values on classifier; remove trainable_params

However, I think the make_save_path was forgotten to be updated because I was receiving errors when trying to run ATM.  This patch fixes those errors.