### PR TITLE
Use python's logging module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,11 @@ jobs:
     working_directory: ~/atm
     docker:
       - image: themattrix/tox
-      - image: mysql:5.7
-        environment:
-            MYSQL_USER: ubuntu
-            MYSQL_ROOT_PASSWORD: ubuntu
-            MYSQL_DATABASE: atm
+      #- image: mysql:5.7
+        #environment:
+            #MYSQL_USER: ubuntu
+            #MYSQL_ROOT_PASSWORD: ubuntu
+            #MYSQL_DATABASE: atm
     steps:
       - checkout
       - run: apt-get -qq update

--- a/atm/__init__.py
+++ b/atm/__init__.py
@@ -10,3 +10,7 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 __all__ = ['config', 'constants', 'database', 'enter_data', 'method', 'metrics',
            'model', 'utilities', 'worker']
+
+from .config import initialize_logging
+
+initialize_logging(config)

--- a/atm/__init__.py
+++ b/atm/__init__.py
@@ -2,15 +2,17 @@
 A multi-user, multi-data AutoML framework.
 """
 from __future__ import absolute_import
+import logging
 import os
 
 # Get the path of the project root, so that the rest of the project can
 # reference files relative to there.
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 
+# this defines which modules will be imported by "from atm import *"
 __all__ = ['config', 'constants', 'database', 'enter_data', 'method', 'metrics',
            'model', 'utilities', 'worker']
 
-from .config import initialize_logging
-
-initialize_logging(config)
+# by default, nothing should be logged
+logger = logging.getLogger('atm')
+logger.addHandler(logging.NullHandler())

--- a/atm/config.py
+++ b/atm/config.py
@@ -3,12 +3,14 @@ from __future__ import absolute_import
 import logging
 import os
 import re
+import socket
 import sys
 from argparse import ArgumentError, ArgumentTypeError, RawTextHelpFormatter
 
 import yaml
 
 from .constants import *
+from .utilities import ensure_directory
 
 
 class Config(object):
@@ -131,56 +133,65 @@ class RunConfig(Config):
     }
 
 
-class LoggingConfig(Config):
+class LogConfig(Config):
     PARAMETERS = [
-        'stdout_level',
-        'file_level',
+        'log_level_stdout',
+        'log_level_file',
         'log_dir',
         'model_dir',
         'metric_dir',
+        'verbose_metrics',
     ]
 
     DEFAULTS = {
+        'log_level_stdout': 'ERROR',
         'log_level_file': 'INFO',
-        'log_level_stdout': 'INFO',
         'log_dir': 'logs',
         'model_dir': 'models',
         'metric_dir': 'metrics',
+        'verbose_metrics': False,
     }
 
 
 def initialize_logging(config):
-    err_levels = ['WARNING', 'ERROR', 'CRITICAL']
     logger = logging.getLogger('atm')
 
+    LEVELS = {
+        'CRITICAL': logging.CRITICAL,
+        'ERROR': logging.ERROR,
+        'WARNING': logging.WARNING,
+        'INFO': logging.INFO,
+        'DEBUG': logging.DEBUG
+    }
+
+    file_level = LEVELS.get(config.log_level_file.upper(), logging.CRITICAL)
+    stdout_level = LEVELS.get(config.log_level_stdout.upper(), logging.CRITICAL)
+    logger.setLevel(min(file_level, stdout_level))
+
+    for h in logger.handlers:
+        logger.removeHandler(h)
+
     if config.log_level_file:
-        level = config.log_level_file.upper()
-        fmt = '%(asctime)-15s %(name)s - %(levelname)s    %(message)s'
-        handler = logging.FileHandler(config.log_dir.stdout)
+        fmt = '%(asctime)-15s %(name)s - %(levelname)s  %(message)s'
+        ensure_directory(config.log_dir)
+        path = os.path.join(config.log_dir, socket.gethostname() + '.txt')
+        handler = logging.FileHandler(path)
         handler.setFormatter(logging.Formatter(fmt))
-    else:
-        logger.
+        handler.setLevel(file_level)
+        logger.addHandler(handler)
 
     if config.log_level_stdout:
-        level = config.log_level_stdout.upper()
         fmt = '%(message)s'
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(logging.Formatter(fmt))
+        handler.setLevel(stdout_level)
+        logger.addHandler(handler)
 
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    log_handler = logging.StreamHandler(sys.stdout)
-    err_handler.setFormatter(logging.Formatter(fmt))
+    if not len(logger.handlers):
+        logger.addHandler(logging.NullHandler())
 
-    logger.setLevel(level)
-    for _handler in logger.handlers:
-        logger.removeHandler(_handler)
-
-    if level in err_levels:
-        logger.addHandler(stdout_handler)
-    else:
-        logger.addHandler(out_handler)
     logger.propagate = False
-
+    logger.debug('Logging set up.')
 
 
 def option_or_path(options, regex=CUSTOM_CLASS_REGEX):
@@ -199,6 +210,33 @@ def option_or_path(options, regex=CUSTOM_CLASS_REGEX):
         raise ArgumentTypeError('%s is not a valid option or path!' % s)
 
     return type_check
+
+
+def add_arguments_logging(parser):
+    """
+    Add all argparse arguments needed to parse logging configuration from the
+    command line.
+    parser: an argparse.ArgumentParser object
+    """
+    # Config file
+    parser.add_argument('--log-config', help='path to yaml logging config file')
+
+    parser.add_argument('--model-dir',
+                        help='Directory where computed models will be saved')
+    parser.add_argument('--metric-dir',
+                        help='Directory where model metrics will be saved')
+    parser.add_argument('--log-dir',
+                        help='Directory where logs will be saved')
+
+    parser.add_argument('--verbose-metrics', default=False, action='store_true',
+                        help='If set, compute full ROC and PR curves and '
+                        'per-label metrics for each classifier')
+    parser.add_argument('--log-level-file',
+                        help='minimum log level to write to the log file')
+    parser.add_argument('--log-level-stdout',
+                        help='minimum log level to write to stdout')
+
+    return parser
 
 
 def add_arguments_aws_s3(parser):
@@ -448,25 +486,26 @@ def add_arguments_datarun(parser):
     return parser
 
 
-def load_config(sql_path=None, run_path=None, aws_path=None, **kwargs):
+def load_config(sql_path=None, run_path=None, aws_path=None, log_path=None, **kwargs):
     """
     Load config objects from yaml files and command line arguments. Command line
     args override yaml files where applicable.
 
     Args:
-        sql_path: path to .yaml file with SQL config info
-        run_path: path to .yaml file with Dataset and Datarun config info
-        aws_path: path to .yaml file with AWS config info
+        sql_path: path to .yaml file with SQL configuration
+        run_path: path to .yaml file with Dataset and Datarun configuration
+        aws_path: path to .yaml file with AWS configuration
+        log_path: path to .yaml file with logging configuration
         **kwargs: miscellaneous arguments specifying individual configuration
             parameters. Any kwargs beginning with sql_ are SQL config
-            arguments, any beginning with aws_ are AWS config, and the rest are
-            assumed to be dataset or datarun config.
+            arguments, any beginning with aws_ are AWS config.
 
-    Returns: sql_conf, run_conf, aws_conf
+    Returns: sql_conf, run_conf, aws_conf, log_conf
     """
     sql_args = {}
     run_args = {}
     aws_args = {}
+    log_args = {}
 
     # kwargs are most likely generated by argparse.
     # Any unspecified argparse arguments will be None, so ignore those. We only
@@ -491,13 +530,19 @@ def load_config(sql_path=None, run_path=None, aws_path=None, **kwargs):
         with open(aws_path) as f:
             aws_args = yaml.load(f)
 
+    if log_path:
+        with open(log_path) as f:
+            log_args = yaml.load(f)
+
     # Use keyword args to override yaml config values
     sql_args.update({k.replace('sql_', ''): v for k, v in kwargs.items()
                      if 'sql_' in k})
     aws_args.update({k.replace('aws_', ''): v for k, v in kwargs.items()
                      if 'aws_' in k})
-    run_args.update({k: v for k, v in kwargs.items()
-                     if 'sql_' not in k and 'aws_' not in k})
+    run_args.update({k: v for k, v in kwargs.items() if k in
+                     RunConfig.PARAMETERS})
+    log_args.update({k: v for k, v in kwargs.items() if k in
+                     LogConfig.PARAMETERS})
 
     # It's ok if there are some extra arguments that get passed in here; only
     # kwargs that correspond to real config values will be stored on the config
@@ -505,5 +550,6 @@ def load_config(sql_path=None, run_path=None, aws_path=None, **kwargs):
     sql_conf = SQLConfig(**sql_args)
     aws_conf = AWSConfig(**aws_args)
     run_conf = RunConfig(**run_args)
+    log_conf = LogConfig(**run_args)
 
-    return sql_conf, run_conf, aws_conf
+    return sql_conf, run_conf, aws_conf, log_conf

--- a/atm/config.py
+++ b/atm/config.py
@@ -144,7 +144,7 @@ class LogConfig(Config):
     ]
 
     DEFAULTS = {
-        'log_level_stdout': 'ERROR',
+        'log_level_stdout': 'INFO',
         'log_level_file': 'INFO',
         'log_dir': 'logs',
         'model_dir': 'models',

--- a/atm/config.py
+++ b/atm/config.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
+import logging
 import os
 import re
+import sys
 from argparse import ArgumentError, ArgumentTypeError, RawTextHelpFormatter
 
 import yaml
@@ -12,11 +14,11 @@ from .constants import *
 class Config(object):
     """
     Class which stores configuration for one aspect of ATM. Subclasses of
-    Config should define, in PARAMETERS and DEFAULTS, respectively, the list of
-    all configurable parameters and any default values for those parameters
-    other than None. The object can be initialized with any number of keyword
-    arguments; only kwargs that are in PARAMETERS will be used. This means you
-    can (relatively) safely do things like
+    Config should define the list of all configurable parameters and any
+    default values for those parameters other than None (in PARAMETERS and
+    DEFAULTS, respectively). The object can be initialized with any number of
+    keyword arguments; only kwargs that are in PARAMETERS will be used. This
+    means you can (relatively) safely do things like
         args = parser.parse_args()
         conf = Config(**vars(args))
     and only relevant parameters will be set.
@@ -127,6 +129,58 @@ class RunConfig(Config):
         'metric': 'f1',
         'score_target': 'cv',
     }
+
+
+class LoggingConfig(Config):
+    PARAMETERS = [
+        'stdout_level',
+        'file_level',
+        'log_dir',
+        'model_dir',
+        'metric_dir',
+    ]
+
+    DEFAULTS = {
+        'log_level_file': 'INFO',
+        'log_level_stdout': 'INFO',
+        'log_dir': 'logs',
+        'model_dir': 'models',
+        'metric_dir': 'metrics',
+    }
+
+
+def initialize_logging(config):
+    err_levels = ['WARNING', 'ERROR', 'CRITICAL']
+    logger = logging.getLogger('atm')
+
+    if config.log_level_file:
+        level = config.log_level_file.upper()
+        fmt = '%(asctime)-15s %(name)s - %(levelname)s    %(message)s'
+        handler = logging.FileHandler(config.log_dir.stdout)
+        handler.setFormatter(logging.Formatter(fmt))
+    else:
+        logger.
+
+    if config.log_level_stdout:
+        level = config.log_level_stdout.upper()
+        fmt = '%(message)s'
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter(fmt))
+
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    log_handler = logging.StreamHandler(sys.stdout)
+    err_handler.setFormatter(logging.Formatter(fmt))
+
+    logger.setLevel(level)
+    for _handler in logger.handlers:
+        logger.removeHandler(_handler)
+
+    if level in err_levels:
+        logger.addHandler(stdout_handler)
+    else:
+        logger.addHandler(out_handler)
+    logger.propagate = False
+
 
 
 def option_or_path(options, regex=CUSTOM_CLASS_REGEX):

--- a/atm/database.py
+++ b/atm/database.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
 from datetime import datetime
 from operator import attrgetter

--- a/atm/enter_data.py
+++ b/atm/enter_data.py
@@ -144,7 +144,7 @@ def enter_data(sql_config, run_config, aws_config=None,
                                      categoricals=part.categoricals,
                                      status=PartitionStatus.INCOMPLETE)
 
-    logger.info('Summary:')
+    logger.info('Data entry complete. Summary:')
     logger.info('\tDataset ID: %d' % dataset.id)
     logger.info('\tTraining data: %s' % dataset.train_path)
     logger.info('\tTest data: %s' % (dataset.test_path or 'None'))

--- a/atm/enter_data.py
+++ b/atm/enter_data.py
@@ -1,5 +1,6 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
+import logging
 import os
 from datetime import datetime, timedelta
 
@@ -9,6 +10,9 @@ from .database import Database
 from .encoder import MetaData
 from .method import Method
 from .utilities import download_data
+
+# load the library-wide logger
+logger = logging.getLogger('atm')
 
 
 def create_dataset(db, run_config, aws_config=None):
@@ -114,15 +118,16 @@ def enter_data(sql_config, run_config, aws_config=None,
         # enumerate all combinations of categorical variables for this method
         method = Method(m)
         method_parts[m] = method.get_hyperpartitions()
-        print('method', m, 'has', len(method_parts[m]), 'hyperpartitions')
+        logger.info('method %s has %d hyperpartitions' %
+                    (m, len(method_parts[m])))
 
     # create hyperpartitions and datarun(s)
     run_ids = []
     if not run_per_partition:
-        print('saving datarun...')
+        logger.debug('saving datarun...')
         datarun = create_datarun(db, dataset, run_config)
 
-    print('saving hyperpartions...')
+    logger.debug('saving hyperpartions...')
     for method, parts in method_parts.items():
         for part in parts:
             # if necessary, create a new datarun for each hyperpartition.
@@ -139,19 +144,16 @@ def enter_data(sql_config, run_config, aws_config=None,
                                      categoricals=part.categoricals,
                                      status=PartitionStatus.INCOMPLETE)
 
-    print('done!')
-    print()
-    print('========== Summary ==========')
-    print('Dataset ID:', dataset.id)
-    print('Training data:', dataset.train_path)
-    print('Test data:', (dataset.test_path or '(None)'))
+    logger.info('Summary:')
+    logger.info('\tDataset ID: %d' % dataset.id)
+    logger.info('\tTraining data: %s' % dataset.train_path)
+    logger.info('\tTest data: %s' % (dataset.test_path or 'None'))
     if run_per_partition:
-        print('Datarun IDs:', ', '.join(map(str, run_ids)))
+        logger.info('\tDatarun IDs: %s' % ', '.join(map(str, run_ids)))
     else:
-        print('Datarun ID:', datarun.id)
-    print('Hyperpartition selection strategy:', datarun.selector)
-    print('Parameter tuning strategy:', datarun.tuner)
-    print('Budget: %d (%s)' % (datarun.budget, datarun.budget_type))
-    print()
+        logger.info('\tDatarun ID: %d' % datarun.id)
+    logger.info('\tHyperpartition selection strategy: %s' % datarun.selector)
+    logger.info('\tParameter tuning strategy: %s' % datarun.tuner)
+    logger.info('\tBudget: %d (%s)' % (datarun.budget, datarun.budget_type))
 
     return run_ids or datarun.id

--- a/atm/model.py
+++ b/atm/model.py
@@ -3,8 +3,9 @@
    :synopsis: Model around classification method.
 
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
+import logging
 import re
 import time
 from collections import defaultdict
@@ -24,6 +25,9 @@ from .constants import *
 from .encoder import DataEncoder, MetaData
 from .method import Method
 from .metrics import cross_validate_pipeline, test_pipeline
+
+# load the library-wide logger
+logger = logging.getLogger('atm')
 
 
 class Model(object):
@@ -110,8 +114,8 @@ class Model(object):
             # features to use
             if pca_dims < 1:
                 dimensions = int(pca_dims * float(self.num_features))
-                print("*** Using PCA to reduce %d features to %d dimensions" %
-                      (self.num_features, dimensions))
+                logger.info("Using PCA to reduce %d features to %d dimensions"
+                            % (self.num_features, dimensions))
                 pca = decomposition.PCA(n_components=dimensions, whiten=whiten)
                 steps.append(('pca', pca))
 

--- a/atm/tests/unit_tests/test_worker.py
+++ b/atm/tests/unit_tests/test_worker.py
@@ -9,7 +9,7 @@ from mock import ANY, Mock, patch
 
 import atm
 from atm import PROJECT_ROOT
-from atm.config import RunConfig, SQLConfig
+from atm.config import RunConfig, SQLConfig, LogConfig
 from atm.constants import METRICS_BINARY, TIME_FMT
 from atm.database import ClassifierStatus, Database, db_session
 from atm.enter_data import enter_data
@@ -183,7 +183,8 @@ def test_test_classifier(db, dataset):
 
 
 def test_save_classifier(db, datarun, model, metrics):
-    worker = Worker(db, datarun, model_dir=MODEL_DIR, metric_dir=METRIC_DIR)
+    log_conf = LogConfig(model_dir=MODEL_DIR, metric_dir=METRIC_DIR)
+    worker = Worker(db, datarun, log_config=log_conf)
     hp = db.get_hyperpartitions(datarun_id=worker.datarun.id)[0]
     classifier = worker.db.start_classifier(hyperpartition_id=hp.id,
                                             datarun_id=worker.datarun.id,

--- a/atm/tests/unit_tests/test_worker.py
+++ b/atm/tests/unit_tests/test_worker.py
@@ -9,7 +9,7 @@ from mock import ANY, Mock, patch
 
 import atm
 from atm import PROJECT_ROOT
-from atm.config import RunConfig, SQLConfig, LogConfig
+from atm.config import LogConfig, RunConfig, SQLConfig
 from atm.constants import METRICS_BINARY, TIME_FMT
 from atm.database import ClassifierStatus, Database, db_session
 from atm.enter_data import enter_data

--- a/atm/utilities.py
+++ b/atm/utilities.py
@@ -1,8 +1,9 @@
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import
 
 import base64
 import hashlib
 import json
+import logging
 import os
 import pickle
 import re
@@ -20,7 +21,9 @@ from btb import ParamTypes
 public_ip = None
 
 # URL which should give us our public-facing IP address
-PUBLIC_IP_URL = "http://ip.42.pl/raw"
+PUBLIC_IP_URL = 'http://ip.42.pl/raw'
+
+logger = logging.getLogger('atm')
 
 
 def hash_dict(dictionary, ignored_keys=None):
@@ -65,7 +68,7 @@ def get_public_ip():
             if match:
                 public_ip = match.group()
         except Exception as e:  # any exception, doesn't matter what
-            print('could not get public IP:', e)
+            logger.error('could not get public IP:', e)
             public_ip = 'localhost'
 
     return public_ip
@@ -195,7 +198,7 @@ def save_model(classifier, model_dir, model):
     attributes.
     """
     path = make_save_path(model_dir, classifier, 'model')
-    print('Saving model in: %s' % path)
+    logger.info('Saving model in: %s' % path)
     with open(path, 'wb') as f:
         pickle.dump(model, f, protocol=pickle.HIGHEST_PROTOCOL)
     return path
@@ -208,7 +211,7 @@ def save_metrics(classifier, metric_dir, metrics):
     the classifier's attributes.
     """
     path = make_save_path(metric_dir, classifier, 'metric')
-    print('Saving metrics in: %s' % path)
+    logger.info('Saving metrics in: %s' % path)
     with open(path, 'w') as f:
         json.dump(metrics, f)
     return path
@@ -268,7 +271,7 @@ def download_file_s3(aws_path, aws_config, local_folder=DATA_DL_PATH):
         path = keyname
 
     if os.path.isfile(path):
-        print('file %s already exists!' % path)
+        logger.warning('file %s already exists!' % path)
         return path
 
     conn = S3Connection(aws_config.access_key, aws_config.secret_key)
@@ -279,10 +282,11 @@ def download_file_s3(aws_path, aws_config, local_folder=DATA_DL_PATH):
     else:
         aws_keyname = keyname
 
-    print('downloading data from S3...')
+    logger.debug('downloading data from S3...')
     s3key = Key(bucket)
     s3key.key = aws_keyname
     s3key.get_contents_to_filename(path)
+    logger.info('file saved at %s' % path)
 
     return path
 
@@ -297,14 +301,15 @@ def download_file_http(url, local_folder=DATA_DL_PATH):
         path = filename
 
     if os.path.isfile(path):
-        print('file %s already exists!' % path)
+        logger.warning('file %s already exists!' % path)
         return path
 
-    print('downloading data from %s...' % url)
+    logger.debug('downloading data from %s...' % url)
     f = urllib2.urlopen(url)
     data = f.read()
-    with open(path, "wb") as outfile:
+    with open(path, 'wb') as outfile:
         outfile.write(data)
+    logger.info('file saved at %s' % path)
 
     return path
 

--- a/atm/worker.py
+++ b/atm/worker.py
@@ -407,8 +407,8 @@ class Worker(object):
 
 
 def work(db, datarun_ids=None, save_files=False, choose_randomly=True,
-         cloud_mode=False, aws_config=None, total_time=None, wait=True,
-         model_dir=None, metric_dir=None, verbose_metrics=False):
+         cloud_mode=False, aws_config=None, log_config=None, total_time=None,
+         wait=True):
     """
     Check the ModelHub database for unfinished dataruns, and spawn workers to
     work on them as they are added. This process will continue to run until it
@@ -421,7 +421,7 @@ def work(db, datarun_ids=None, save_files=False, choose_randomly=True,
         order. If False, work on them in sequential order (by ID)
     cloud_mode: if True, save processed datasets to AWS. If this option is set,
         aws_config must be supplied.
-    aws_config (optional): if cloud_mode is set, this myst be an AWSConfig
+    aws_config (optional): if cloud_mode is set, this must be an AWSConfig
         object with connection details for an S3 bucket.
     total_time (optional): if set to an integer, this worker will only work for
         total_time seconds. Otherwise, it will continue working until all
@@ -465,8 +465,7 @@ def work(db, datarun_ids=None, save_files=False, choose_randomly=True,
         # actual work happens here
         worker = Worker(db, run, save_files=save_files,
                         cloud_mode=cloud_mode, aws_config=aws_config,
-                        public_ip=public_ip, model_dir=model_dir,
-                        metric_dir=metric_dir, verbose_metrics=verbose_metrics)
+                        log_config=log_config, public_ip=public_ip)
         try:
             worker.run_classifier()
         except ClassifierError:

--- a/atm/worker.py
+++ b/atm/worker.py
@@ -16,6 +16,7 @@ import numpy as np
 from boto.s3.connection import Key as S3Key
 from boto.s3.connection import S3Connection
 
+from .config import LogConfig
 from .constants import *
 from .database import ClassifierStatus, db_session
 from .model import Model
@@ -42,8 +43,7 @@ class ClassifierError(Exception):
 
 class Worker(object):
     def __init__(self, database, datarun, save_files=True, cloud_mode=False,
-                 aws_config=None, public_ip='localhost', model_dir=None,
-                 metric_dir=None, verbose_metrics=False):
+                 aws_config=None, log_config=None, public_ip='localhost'):
         """
         database: Database object with connection information
         datarun: Datarun ORM object to work on.
@@ -57,10 +57,11 @@ class Worker(object):
         self.cloud_mode = cloud_mode
         self.aws_config = aws_config
         self.public_ip = public_ip
-        self.verbose_metrics = verbose_metrics
 
-        self.model_dir = model_dir
-        self.metric_dir = metric_dir
+        log_config = log_config or LogConfig()
+        self.model_dir = log_config.model_dir
+        self.metric_dir = log_config.metric_dir
+        self.verbose_metrics = log_config.verbose_metrics
         ensure_directory(self.model_dir)
         ensure_directory(self.metric_dir)
 

--- a/scripts/end_to_end_test.py
+++ b/scripts/end_to_end_test.py
@@ -61,8 +61,8 @@ parser.add_argument('--processes', help='number of processes to run concurrently
                     type=int, default=4)
 
 args = parser.parse_args()
-sql_config, run_config, _ = load_config(sql_path=SQL_CONFIG,
-                                        run_path=RUN_CONFIG)
+sql_config, run_config, _, _ = load_config(sql_path=SQL_CONFIG,
+                                           run_path=RUN_CONFIG)
 
 db = Database(**vars(sql_config))
 

--- a/scripts/enter_data.py
+++ b/scripts/enter_data.py
@@ -3,7 +3,9 @@ from __future__ import print_function
 import argparse
 import warnings
 
-from atm.config import *
+from atm.config import (add_arguments_aws_s3, add_arguments_sql,
+                        add_arguments_datarun, add_arguments_logging,
+                        load_config, initialize_logging)
 from atm.enter_data import enter_data
 
 warnings.filterwarnings("ignore")
@@ -24,15 +26,19 @@ folder for more information. """)
     add_arguments_aws_s3(parser)
     add_arguments_sql(parser)
     add_arguments_datarun(parser)
+    add_arguments_logging(parser)
     parser.add_argument('--run-per-partition', default=False, action='store_true',
                         help='if set, generate a new datarun for each hyperpartition')
 
     args = parser.parse_args()
 
     # create config objects from the config files and/or command line args
-    sql_config, run_config, aws_config = load_config(sql_path=args.sql_config,
-                                                     run_path=args.run_config,
-                                                     aws_path=args.aws_config,
-                                                     **vars(args))
+    sql_conf, run_conf, aws_conf, log_conf = load_config(sql_path=args.sql_config,
+                                                         run_path=args.run_config,
+                                                         aws_path=args.aws_config,
+                                                         log_path=args.log_config,
+                                                         **vars(args))
+    initialize_logging(log_conf)
+
     # create and save the dataset and datarun
-    enter_data(sql_config, run_config, aws_config, args.run_per_partition)
+    enter_data(sql_conf, run_conf, aws_conf, args.run_per_partition)

--- a/scripts/evaluate_btb.py
+++ b/scripts/evaluate_btb.py
@@ -39,9 +39,9 @@ def btb_test(dataruns=None, datasets=None, processes=1, graph=False, **kwargs):
     Tuner and selector will be specified in **kwargs, along with the rest of the
     standard datarun arguments.
     """
-    sql_conf, run_conf, _ = load_config(sql_path=SQL_CONFIG,
-                                        run_path=RUN_CONFIG,
-                                        **kwargs)
+    sql_conf, run_conf, _, _ = load_config(sql_path=SQL_CONFIG,
+                                           run_path=RUN_CONFIG,
+                                           **kwargs)
 
     db = Database(**vars(sql_conf))
     datarun_ids = dataruns or []

--- a/scripts/method_test.py
+++ b/scripts/method_test.py
@@ -36,8 +36,8 @@ parser.add_argument('--method', help='code for method to test')
 parser.add_argument('--method-path', help='path to JSON config for method to test')
 
 args = parser.parse_args()
-sql_config, run_config, aws_config = load_config(sql_path=SQL_CONFIG,
-                                                 run_path=RUN_CONFIG)
+sql_config, run_config, aws_config, _ = load_config(sql_path=SQL_CONFIG,
+                                                    run_path=RUN_CONFIG)
 db = Database(**vars(sql_config))
 
 print('creating dataruns...')

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -8,8 +8,7 @@ import warnings
 from atm.config import (add_arguments_aws_s3, add_arguments_logging,
                         add_arguments_sql, load_config, initialize_logging)
 from atm.database import Database
-from atm.worker import (DEFAULT_LOG_DIR, DEFAULT_METRIC_DIR, DEFAULT_MODEL_DIR,
-                        Worker, work)
+from atm.worker import Worker, work
 
 warnings.filterwarnings('ignore')
 
@@ -44,9 +43,6 @@ if __name__ == '__main__':
          save_files=args.save_files,
          cloud_mode=args.cloud_mode,
          aws_config=aws_config,
+         log_config=log_config,
          total_time=args.time,
-         wait=False,
-         model_dir=log_config.model_dir,
-         metric_dir=log_config.metric_dir,
-         log_dir=log_config.log_dir,
-         verbose_metrics=log_config.verbose_metrics)
+         wait=False)


### PR DESCRIPTION
This pull request removes print statements from the project entirely, in favor of configurable logging to stdout and log files with `logging`. The main benefit of this is that atm can now be used as a library without cluttering stdout with status messages. 

This PR also adds a new LogConfig class for specifying log files, log levels, and model/metrics directories. The default configuration is unchanged: log files are in `./log/`, model files in `./models/`, and metrics in `./metrics/`. Users can specify the log level for both the log file and stdout separately. For example:

```
python scripts/enter_data.py --log-level-stdout info --log-level-file debug
```

see https://docs.python.org/2/library/logging.html for more details on log levels.

This addresses #39.