### PR TITLE
Fix pandas.Series.items does not exist in py2

### DIFF
--- a/atm/database.py
+++ b/atm/database.py
@@ -335,7 +335,7 @@ class Database(object):
 
             for _, r in df.iterrows():
                 # replace NaN and NaT with None
-                for k, v in list(r.items()):
+                for k, v in list(r.iteritems()):
                     if pd.isnull(v):
                         r[k] = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sqlalchemy==1.1.14
 numpy==1.13.1
 boto==2.48.0
-pandas==0.20.3
+pandas==0.22.0
 scikit-learn==0.18.2
 scipy==0.19.1
 sklearn-pandas==1.5.0

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         'sqlalchemy>=1.1',
         'numpy>=1.13',
         'boto>=2.48',
-        'pandas>=0.20',
+        'pandas>=0.22',
         'scikit-learn>=0.18',
         'scipy>=0.19',
         'sklearn-pandas>=1.5',


### PR DESCRIPTION
The fact that the `items` attribute exists in py3 is just a coincidence.
It should be `iteritems`. See
https://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.iteritems.html.

This closes #85 