### PR TITLE
atm uses btb release tagged 0.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ sklearn-pandas==1.5.0
 mysqlclient>=1.2
 pyyaml==3.12
 joblib==0.11
--e git+https://github.com/hdi-project/btb.git@v0.1.0#egg=btb
+btb==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     # the proper tools.
     # https://www.python.org/dev/peps/pep-0440/#direct-references
     dependency_links=[
-        'git+ssh://git@github.com/hdi-project/btb.git#egg=btb-0.0.1',
+        'git+https://git@github.com/hdi-project/btb.git@v0.1.0#egg=btb-0.1.0',
     ],
 
     # This variable is used to specify requirements for *this file* to run.
@@ -95,4 +95,3 @@ setup(
         'pytest-cov>=2.5',
     ]
 )
-


### PR DESCRIPTION
Should unbreak btb versioning issue and pull correctly from tag 0.1.0.