### PR TITLE
Generate the coverage report for codecov

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 extras = tests
 commands =
-    /usr/bin/env python setup.py test
+    /usr/bin/env python -m pytest --cov=atm
 
 
 [testenv:lint]


### PR DESCRIPTION
Change the test command used by tox to ensure that the coverage report is generated and sent to codecov by travis.